### PR TITLE
Add support for string literal usage for C++ 20

### DIFF
--- a/obfuscate.h
+++ b/obfuscate.h
@@ -212,6 +212,28 @@ namespace ay
 		return obfuscated_data; \
 	}()
 
+#if __cpp_nontype_template_args >= 201911
+
+template <unsigned long long N>
+struct ObfuscateString
+{
+	char data[N]{};
+	constexpr ObfuscateString(char const (&d)[N])
+	{
+		for (unsigned long long i = 0; i < N; i++)
+		{
+			data[i] = d[i];
+		}
+	};
+};
+
+template <ObfuscateString s>
+constexpr const char *operator""_o()
+{
+	return AY_OBFUSCATE(s.data);
+}
+#endif
+
 /* -------------------------------- LICENSE ------------------------------------
 
 Public Domain (http://www.unlicense.org)


### PR DESCRIPTION
With this you can obfuscate strings using an "_o" suffix, e.g:
`std::cout << "hello world"_o << std::endl;`
I'm using this for my own programs because it looks cleaner, thought I'd suggest it. 