### PR TITLE
Fix exception at runtime on MSVC when /RTCc is enabled

### DIFF
--- a/obfuscate.h
+++ b/obfuscate.h
@@ -74,7 +74,7 @@ namespace ay
 		// Obfuscate with a simple XOR cipher based on key
 		for (size_type i = 0; i < size; i++)
 		{
-			data[i] ^= char(key >> ((i % 8) * 8));
+			data[i] ^= char((key >> ((i % 8) * 8)) & 0xFF);
 		}
 	}
 


### PR DESCRIPTION
'key >> ((i % 8) * 8) ' expression evaluates to a key_type, ie  unsigned  long long. Casting the expression down to a char results in a data loss that is catched by /RTCc runtime check on MSVC.

Truncating the value solves the problem.

See https://learn.microsoft.com/en-us/cpp/build/reference/rtc-run-time-error-checks?view=msvc-170