### PR TITLE
Update to GoogleTest v1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ if (GENERATE_TESTS)
     FetchContent_Declare(
       googletest
       # Specify the commit you depend on and update it regularly.
-      URL https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip
+      URL https://github.com/google/googletest/archive/52eb8108c5bdec04579160ae17225d66034bd723.zip
     )
     # For Windows: Prevent overriding the parent project's compiler/linker settings
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
Update to the latest tagged version of GoogleTest which increases the minimum required version of CMake to 3.16.  This improves compatibility with CMake 4.0 and later which fail with the older version because compatibility with CMake < 3.5 has been removed from CMake.

No changes are required for the tests to build and run with the new version of GoogleTest.